### PR TITLE
Remove deprecated class

### DIFF
--- a/grape-active_model_serializers.gemspec
+++ b/grape-active_model_serializers.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.licenses      = ['MIT']
 
   gem.add_dependency 'grape'
-  gem.add_dependency 'active_model_serializers', '>= 0.10.0.rc2'
+  gem.add_dependency 'active_model_serializers', '>= 0.10.0.rc5'
 
   gem.add_development_dependency 'rails-api', '>= 0.4.0'
   gem.add_development_dependency 'rspec'

--- a/lib/grape-active_model_serializers/formatter.rb
+++ b/lib/grape-active_model_serializers/formatter.rb
@@ -47,7 +47,7 @@ module Grape
           options[:adapter_options][:include] = options[:include] if options[:include]
 
           serializer_instance = serializer.new(resource, options[:serializer_options])
-          ActiveModel::Serializer::Adapter.create(serializer_instance, options[:adapter_options])
+          ActiveModelSerializers::Adapter.create(serializer_instance, options[:adapter_options])
         end
 
         def build_options_from_endpoint(endpoint)


### PR DESCRIPTION
After we upgrade active_model_serializers, some class has been marked as deprecated class, so we 
 should remove it to avoid to spam our log stuff

![Screen Shot 2019-10-09 at 9 43 38 AM](https://user-images.githubusercontent.com/1973623/66447695-50db4300-ea79-11e9-978f-395776334581.png)