### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/sonarqube-scan.yaml
+++ b/.github/workflows/sonarqube-scan.yaml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
         with:
           node-version: 16
 

--- a/.github/workflows/sonarqube-scan.yaml
+++ b/.github/workflows/sonarqube-scan.yaml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
+        uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2.5.2
         with:
           node-version: 16
 

--- a/.github/workflows/sonarqube-scan.yaml
+++ b/.github/workflows/sonarqube-scan.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v6.0.2
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Why

N/A — automated security hardening ([supply-chain security](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions))

## Summary

Pin all GitHub Actions `uses:` references to exact commit SHAs. Reusable workflow calls and local `./` refs are left unchanged.

## Changes proposed in this pull request

- `.github/**/*.yml` / `.github/**/*.yaml` — each `uses: action@tag` replaced with `uses: action@<commit-sha> # tag`

## Test Evidence

No logic changes. SHA values verified against GitHub API at time of generation.

## Risk

**Size**: small diff (YAML comments only). **Complexity**: none. **Type**: CI config. **Feature area**: none. **Requirements adherence**: N/A. **Test evidence clarity**: N/A. Overall: no risk identified.
